### PR TITLE
Avoid `windows` crate types in public API

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,9 +10,10 @@ jobs:
     name: create-release
     runs-on: windows-2019
     steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 1
+      - uses: actions/checkout@v3
+      
+      - name: Check semver
+        uses: obi1kenobi/cargo-semver-checks-action@v2
 
       - uses: actions-rs/toolchain@v1
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "win32job"
-version = "1.0.3"
+version = "2.0.0"
 authors = ["Ohad Ravid <ohad.rv@gmail.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/src/job.rs
+++ b/src/job.rs
@@ -32,9 +32,7 @@ impl Job {
     }
 
     /// Create an anonymous job object and sets it's limit according to `info`.
-    /// Note: This method shouldn't change the provided `info`, but the internal Windows API
-    /// require a mutable pointer, which means this function requires &mut as well.
-    pub fn create_with_limit_info(info: &mut ExtendedLimitInfo) -> Result<Self, JobError> {
+    pub fn create_with_limit_info(info: &ExtendedLimitInfo) -> Result<Self, JobError> {
         let job = Self::create()?;
         job.set_extended_limit_info(info)?;
 

--- a/src/job.rs
+++ b/src/job.rs
@@ -97,7 +97,7 @@ impl Job {
     pub fn assign_current_process(&self) -> Result<(), JobError> {
         let current_proc_handle = get_current_process();
 
-        self.assign_process(current_proc_handle.0)
+        self.assign_process(current_proc_handle)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 //! or by creating an empty one using `new()`, use helper methods to configure
 //! the required limits, and finally set the info to the job.
 //!
-//! ```edition2018
+//! ```edition2021
 //! use win32job::*;
 //! # fn main() -> Result<(), JobError> {
 //!
@@ -28,7 +28,7 @@
 //! ```
 //!
 //! Which is equivalnent to:
-//! ```edition2018
+//! ```edition2021
 //! use win32job::*;
 //! # fn main() -> Result<(), JobError> {
 //!
@@ -37,33 +37,6 @@
 //!
 //! info.limit_working_memory(1 * 1024 * 1024,  4 * 1024 * 1024)
 //!     .limit_priority_class(PriorityClass::BelowNormal);
-//!
-//! job.set_extended_limit_info(&mut info)?;
-//! job.assign_current_process()?;
-//! #   info.clear_limits();
-//! #   job.set_extended_limit_info(&mut info)?;
-//! #   Ok(())
-//! # }
-//! ```
-//!
-//! # Using the low level API
-//!
-//! The most basic API is getting an `ExtendedLimitInfo` object and
-//! manipulating the raw `JOBOBJECT_BASIC_LIMIT_INFORMATION`, and then set it back to the job.
-//!
-//! It's important to remeber to set the needed `LimitFlags` for each limit used.
-//!
-//! ```edition2018
-//! use win32job::*;
-//! # fn main() -> Result<(), JobError> {
-//! use windows::Win32::System::JobObjects::JOB_OBJECT_LIMIT_WORKINGSET;
-//!
-//! let job = Job::create()?;
-//! let mut info = job.query_extended_limit_info()?;
-//!
-//! info.0.BasicLimitInformation.MinimumWorkingSetSize = 1 * 1024 * 1024;
-//! info.0.BasicLimitInformation.MaximumWorkingSetSize = 4 * 1024 * 1024;
-//! info.0.BasicLimitInformation.LimitFlags |= JOB_OBJECT_LIMIT_WORKINGSET;
 //!
 //! job.set_extended_limit_info(&mut info)?;
 //! job.assign_current_process()?;

--- a/src/limits.rs
+++ b/src/limits.rs
@@ -125,7 +125,7 @@ mod tests {
 
             let memory_info = get_process_memory_info(get_current_process()).unwrap();
 
-            assert!(memory_info.WorkingSetSize <= max * 2);
+            assert!(memory_info.working_set_size <= max * 2);
 
             info.clear_limits();
 

--- a/src/limits.rs
+++ b/src/limits.rs
@@ -13,6 +13,7 @@ use windows::Win32::System::{
 #[derive(Debug)]
 pub struct ExtendedLimitInfo(pub(crate) JOBOBJECT_EXTENDED_LIMIT_INFORMATION);
 
+#[derive(Debug, Clone, Copy)]
 #[repr(u32)]
 pub enum PriorityClass {
     Normal = NORMAL_PRIORITY_CLASS.0,

--- a/src/limits.rs
+++ b/src/limits.rs
@@ -1,5 +1,3 @@
-use std::mem;
-
 use windows::Win32::System::{
     JobObjects::{
         JOBOBJECT_EXTENDED_LIMIT_INFORMATION, JOB_OBJECT_LIMIT_AFFINITY,
@@ -12,7 +10,8 @@ use windows::Win32::System::{
     },
 };
 
-pub struct ExtendedLimitInfo(pub JOBOBJECT_EXTENDED_LIMIT_INFORMATION);
+#[derive(Debug)]
+pub struct ExtendedLimitInfo(pub(crate) JOBOBJECT_EXTENDED_LIMIT_INFORMATION);
 
 #[repr(u32)]
 pub enum PriorityClass {
@@ -36,7 +35,7 @@ impl Default for ExtendedLimitInfo {
 impl ExtendedLimitInfo {
     /// Return an empty extended info objects, without any limits.
     pub fn new() -> Self {
-        let inner: JOBOBJECT_EXTENDED_LIMIT_INFORMATION = unsafe { mem::zeroed() };
+        let inner = Default::default();
         ExtendedLimitInfo(inner)
     }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -3,43 +3,66 @@ use std::{io, mem};
 use windows::Win32::{
     Foundation::HANDLE,
     System::{
-        ProcessStatus::{GetProcessMemoryInfo, PROCESS_MEMORY_COUNTERS},
+        ProcessStatus::{GetProcessMemoryInfo, PROCESS_MEMORY_COUNTERS_EX},
         Threading::{GetCurrentProcess, GetProcessAffinityMask},
     },
 };
 
 /// Return a pseudo handle to the current process.
 /// See also [Microsoft Docs](https://docs.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-getcurrentprocess) for this function.
-pub fn get_current_process() -> HANDLE {
-    unsafe { GetCurrentProcess() }
+pub fn get_current_process() -> isize {
+    unsafe { GetCurrentProcess() }.0
+}
+
+#[derive(Debug, Clone)]
+pub struct ProcessMemoryCounters {
+    pub page_fault_count: u32,
+    pub peak_working_set_size: usize,
+    pub working_set_size: usize,
+    pub quota_peak_paged_pool_usage: usize,
+    pub quota_paged_pool_usage: usize,
+    pub quota_peak_non_paged_pool_usage: usize,
+    pub quota_non_paged_pool_usage: usize,
+    pub pagefile_usage: usize,
+    pub peak_pagefile_usage: usize,
+    pub private_usage: usize,
 }
 
 /// Retrieves information about the memory usage of the specified process.
 /// See also [Microsoft Docs](https://docs.microsoft.com/en-us/windows/win32/api/psapi/nf-psapi-getprocessmemoryinfo) for this function.
-pub fn get_process_memory_info(
-    process_handle: HANDLE,
-) -> Result<PROCESS_MEMORY_COUNTERS, io::Error> {
-    let mut counters: PROCESS_MEMORY_COUNTERS = PROCESS_MEMORY_COUNTERS::default();
+pub fn get_process_memory_info(process_handle: isize) -> Result<ProcessMemoryCounters, io::Error> {
+    let mut counters = PROCESS_MEMORY_COUNTERS_EX::default();
     unsafe {
         GetProcessMemoryInfo(
-            process_handle,
-            &mut counters as *mut _,
-            mem::size_of::<PROCESS_MEMORY_COUNTERS>() as u32,
+            HANDLE(process_handle),
+            &mut counters as *mut _ as *mut _,
+            mem::size_of_val(&counters) as u32,
         )
-    }
-    .map_err(|e| e.into())
-    .map(|_| counters)
+    }?;
+
+    Ok(ProcessMemoryCounters {
+        page_fault_count: counters.PageFaultCount,
+        peak_working_set_size: counters.PeakWorkingSetSize,
+        working_set_size: counters.WorkingSetSize,
+        quota_peak_paged_pool_usage: counters.QuotaPeakPagedPoolUsage,
+        quota_paged_pool_usage: counters.QuotaPagedPoolUsage,
+        quota_peak_non_paged_pool_usage: counters.QuotaPeakNonPagedPoolUsage,
+        quota_non_paged_pool_usage: counters.QuotaNonPagedPoolUsage,
+        pagefile_usage: counters.PagefileUsage,
+        peak_pagefile_usage: counters.PeakPagefileUsage,
+        private_usage: counters.PrivateUsage,
+    })
 }
 
 /// Retrieves the process affinity mask for the specified process and the system affinity mask for the system.
 /// See also [Microsoft Docs](https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-getprocessaffinitymask) for this function.
-pub fn get_process_affinity_mask(process_handle: HANDLE) -> Result<(usize, usize), io::Error> {
+pub fn get_process_affinity_mask(process_handle: isize) -> Result<(usize, usize), io::Error> {
     let mut process_affinity_mask = 0usize;
     let mut system_affinity_mask = 0usize;
 
     unsafe {
         GetProcessAffinityMask(
-            process_handle,
+            HANDLE(process_handle),
             &mut process_affinity_mask as *mut _,
             &mut system_affinity_mask as *mut _,
         )


### PR DESCRIPTION
Followup to #3 + `Fix a bug in query_process_id_list` which I'll backport.

We can't have `impl From<windows::...> for Handle` (for a custom `Handle` type) because then every `windows` version change will be a breaking change 😢, so I decided to use plain `isize` for simplicity. 

~Currently a draft, since I still need to expose `JOBOBJECT_EXTENDED_LIMIT_INFORMATION` in a sanitize way.~

Decided not to expose it since the user always needs to mark the right flags which is error prone, better to have people submit a PR.


cc @Kharosx0 @sunshowers