### PR TITLE
Backport bugfix in `query_process_id_list` to v1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,9 +10,10 @@ jobs:
     name: create-release
     runs-on: windows-2019
     steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 1
+      - uses: actions/checkout@v3
+      
+      - name: Check semver
+        uses: obi1kenobi/cargo-semver-checks-action@v2
 
       - uses: actions-rs/toolchain@v1
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "win32job"
-version = "1.0.2"
+version = "1.0.4"
 authors = ["Ohad Ravid <ohad.rv@gmail.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
`query_process_id_list` would return an incorrect result, where the first process id in the list was always missing (and an extra 0 would be added to the end of the list)